### PR TITLE
modify to use heroku api

### DIFF
--- a/src/apis/users.js
+++ b/src/apis/users.js
@@ -7,8 +7,7 @@ export default {
   },
   // 使用者註冊
   signUp({ account, name, email, password, checkPassword }) {
-    // FIXME: 等候端Deploy到heroku之後進行修改
-    return apiHelper2.post('/users', {
+    return apiHelper.post('/users', {
       account,
       name,
       email,

--- a/src/views/User/UserRegister.vue
+++ b/src/views/User/UserRegister.vue
@@ -44,10 +44,18 @@ export default {
         this.$router.push({ name: 'UserLogin' })
       } catch (err) {
         this.isProcessing = false
-        console.log(err)
+        let message = ''
+        if (err.response) {
+          console.log(err.response.data)
+          message = err.response.data.message
+        } else {
+          console.log(err)
+          message = err.message
+        }
+
         Toast.fire({
           icon: 'error',
-          title: `帳號註冊失敗！\n ${err.message}`,
+          title: `帳號註冊失敗！\n ${message}`,
         })
       }
     },


### PR DESCRIPTION
換成串接heroku api
修改提示訊息的顯示

> 以下是後端會出現的註冊錯誤訊息：

'Email already exists' (401) ,
'Account already exists' (401), 
'Required fields didn't exist' (400), 
'The name should not exceed 50 words' (400), 
'The account should only include number', letter and underline' (400), 
'Password value is not equal to checkPassword' (400)

> 後端預計之後才會把account 以及 password 加上上限50字的檢查