### PR TITLE
Feature c/vue socket.io

### DIFF
--- a/src/components/UserProfile.vue
+++ b/src/components/UserProfile.vue
@@ -37,7 +37,10 @@
         </button>
       </div>
       <div v-if="!isCurrentUser" class="user-profile__action__other">
-        <button>
+        <button
+          @click.stop.prevent="handleClickMessege"
+          :disabled="isProcessing"
+        >
           <img
             class="user-profile__action__icon"
             src="@/assets/images/btn_messege.svg"
@@ -145,6 +148,26 @@ export default {
     //打開編輯個人資料 Modal
     handleToggleModal() {
       this.isModalOpen = !this.isModalOpen
+    },
+    // 開啟私訊按鈕
+    handleClickMessege() {
+      // TODO:待測試
+      console.log('handleClickMessege')
+      console.log('targetUserId', this.user.id)
+      console.log('currentUserId', this.currentUser.id)
+      // 這邊先joinPrivateRoom
+      this.isProcessing = true
+      this.$socket.emit(
+        'joinPrivateRoom',
+        { targetUserId: this.user.id, currentUserId: this.currentUser.id },
+        (response) => {
+          // 回傳room_id
+          console.log('response', response)
+          // 然後跳轉私訊頁面
+          const room_id = ''
+          this.$router.push({ name: 'PrivateRoom', params: { room_id } })
+        }
+      )
     },
   },
 }

--- a/src/main.js
+++ b/src/main.js
@@ -65,14 +65,23 @@ new Vue({
     error(error) {
       console.log('socket error', error)
     },
+    // TODO:這邊之後如果沒有需要就可以刪掉
     // 公開聊天室(系統通知)
     announce(data) {
       console.log('announce back', data)
+    },
+    // 公開聊天室(線上的使用者)
+    publicUser(data) {
+      console.log('publicUser back', data)
     },
     // 公開聊天室(訊息通知)
     publicMessage(data) {
       console.log('publicMessage back', data)
     },
+    // 私人聊天室(訊息通知)
+    privateMessage(data) {
+      console.log('privateMessage back', data)
+    }
   },
 }).$mount('#app')
 

--- a/src/main.js
+++ b/src/main.js
@@ -71,8 +71,8 @@ new Vue({
       console.log('announce back', data)
     },
     // 公開聊天室(線上的使用者)
-    publicUser(data) {
-      console.log('publicUser back', data)
+    publicUsers(data) {
+      console.log('publicUsers back', data)
     },
     // 公開聊天室(訊息通知)
     publicMessage(data) {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -110,7 +110,7 @@ export default {
   },
   // 設定公開聊天室線上的使用者
   SOCKET_publicUsers(context, data) {
-    context.commit('setpublicUsers', data)
+    context.commit('setPublicUsers', data)
   },
   // 公開聊天室系統通知
   SOCKET_announce(context, data) {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -109,16 +109,15 @@ export default {
     context.commit('setPrivateRooms', data)
   },
   // 設定公開聊天室線上的使用者
-  SOCKET_publicUser(context, data) {
-    context.commit('setPublicUser', data)
+  SOCKET_publicUsers(context, data) {
+    context.commit('setpublicUsers', data)
   },
   // 公開聊天室系統通知
   SOCKET_announce(context, data) {
     console.log('SOCKET_announce back', data)
     context.commit('pushPublicAllMessages', {
+      ...data,
       isPill: true,
-      // FIXME:後端會幫忙統一成content
-      content: data.message,
     })
   },
   SOCKET_publicMessage(context, data) {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -108,24 +108,24 @@ export default {
   setPrivateRooms(context, data) {
     context.commit('setPrivateRooms', data)
   },
-  // 測試socket呼叫到的對應action
+  // 設定公開聊天室線上的使用者
+  SOCKET_publicUser(context, data) {
+    context.commit('setPublicUser', data)
+  },
+  // 公開聊天室系統通知
   SOCKET_announce(context, data) {
     console.log('SOCKET_announce back', data)
-    // TODO:另外設定
     context.commit('pushPublicAllMessages', {
       isPill: true,
+      // FIXME:後端會幫忙統一成content
       content: data.message,
     })
   },
   SOCKET_publicMessage(context, data) {
     console.log('SOCKET_publicMessage back', data)
-    // TODO:另外設定
-    context.commit('pushPublicAllMessages', {
-      isPill: false,
-      isSelf: data.userId === context.state.currentUser.id,
-      content: data.content,
-      avatar: data.avatar,
-      createdAt: data.createdAt,
-    })
+    context.commit('pushPublicAllMessages', data)
+  },
+  SOCKET_privateMessage(context, data) {
+    console.log('SOCKET_privateMessage back', data)
   },
 }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -110,4 +110,7 @@ export default {
   setPrivateRooms(state, data) {
     state.privateRooms.room = data
   },
+  setPublicUser(state, data) {
+    state.publicUser = [...data]
+  }
 }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -102,7 +102,7 @@ export default {
     state.isReplyRefresh = isRefresh
   },
   setPublicAllMessages(state, data) {
-    state.publicAllMessages = data
+    state.publicAllMessages = [...data]
   },
   pushPublicAllMessages(state, data) {
     state.publicAllMessages.push(data)

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -16,10 +16,12 @@ export default {
     // TODO:socket disconnect
     if (Vue.prototype.$socket.connected) {
       console.log('呼叫 socket disconnect')
-      // FIXME:如果在公共聊天室，要發送離開事件
-      if (router.currentRoute.name === 'UserAllTweets') {
+      // 如果在公共聊天室，要發送離開事件
+      if (router.currentRoute.name === 'PublicRoom') {
         console.log('登出前呼叫離開房間')
         Vue.prototype.$socket.emit('leavePublicRoom')
+      } else if (router.currentRoute.name === 'Private' || router.currentRoute.name === 'PrivateRoom') {
+        Vue.prototype.$socket.emit('leavePrivateRoom')
       }
       Vue.prototype.$socket.disconnect()
       Vue.prototype.$socket.auth.token = ''
@@ -110,7 +112,7 @@ export default {
   setPrivateRooms(state, data) {
     state.privateRooms.room = data
   },
-  setPublicUser(state, data) {
-    state.publicUser = [...data]
+  setPublicUsers(state, data) {
+    state.publicUsers = [...data]
   }
 }

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -41,6 +41,8 @@ export default {
   isReplyModalOpen: false,
   // 是否回覆成功需要刷新
   isReplyRefresh: false,
+  // 公開聊天室線上使用者
+  publicUser: [],
   // 公開聊天室訊息
   publicAllMessages: [],
   //私人聊天室們

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -42,7 +42,7 @@ export default {
   // 是否回覆成功需要刷新
   isReplyRefresh: false,
   // 公開聊天室線上使用者
-  publicUser: [],
+  publicUsers: [],
   // 公開聊天室訊息
   publicAllMessages: [],
   //私人聊天室們

--- a/src/views/User/PrivateRoom.vue
+++ b/src/views/User/PrivateRoom.vue
@@ -33,6 +33,7 @@
 
 <script>
 import usersAPI from '@/apis/users'
+import { Toastification } from './../../utils/mixins'
 import { mapState } from 'vuex'
 
 import Head from '@/components/Head'
@@ -41,6 +42,7 @@ import ChatRoom from '@/components/ChatRoom'
 
 export default {
   name: 'PrivateRoom',
+  mixins: [Toastification],
   components: {
     Head,
     ChatList,

--- a/src/views/User/PublicRoom.vue
+++ b/src/views/User/PublicRoom.vue
@@ -88,9 +88,9 @@ export default {
   computed: {
     ...mapState(['publicAllMessages']),
   },
-  created() {
+  async created() {
     console.log('created------------joinPublicRoom')
-    this.fetchAllMessages()
+    await this.fetchAllMessages()
     this.$socket.emit('joinPublicRoom')
   },
   beforeDestroy() {
@@ -109,6 +109,7 @@ export default {
       try {
         this.isLoading = true
         const { data } = await usersAPI.messages.getPublicAll()
+        console.log('fetchAllMessages', data)
         this.$store.dispatch('setPublicAllMessages', data)
         this.isLoading = false
       } catch (err) {
@@ -130,7 +131,8 @@ export default {
     handleNewChatSend(content) {
       console.log('handleNewChatSend', content)
       this.$socket.emit('publicMessage', {
-        userId: this.$store.getters.getCurrentUser.id,
+        UserId: this.$store.getters.getCurrentUser.id,
+        RoomId: 5,
         content,
       })
     },

--- a/src/views/User/PublicRoom.vue
+++ b/src/views/User/PublicRoom.vue
@@ -105,11 +105,8 @@ export default {
   computed: {
     ...mapState(['publicAllMessages']),
   },
-  async created() {
-    await this.fetchAllMessages()
-    console.log('created------------joinPublicRoom')
-    this.$socket.emit('joinPublicRoom')
-    this.isJoin = true
+  created() {
+    this.openPublicRoom()
   },
   beforeDestroy() {
     if (this.isJoin) {
@@ -121,10 +118,16 @@ export default {
     connect() {
       console.log('publicRoon socket connected', this.$socket.connected)
       // 斷線重連，重新加入房間
-      this.$socket.emit('joinPublicRoom')
+      this.openPublicRoom()
     },
   },
   methods: {
+    async openPublicRoom() {
+      await this.fetchAllMessages()
+      console.log('created------------joinPublicRoom')
+      this.$socket.emit('joinPublicRoom')
+      this.isJoin = true
+    },
     async fetchAllMessages() {
       try {
         this.isLoading = true

--- a/src/views/User/PublicRoom.vue
+++ b/src/views/User/PublicRoom.vue
@@ -17,6 +17,7 @@
 
 <script>
 import usersAPI from '@/apis/users'
+import { Toastification } from './../../utils/mixins'
 import { mapState } from 'vuex'
 
 import Head from '@/components/Head'
@@ -25,6 +26,7 @@ import ChatRoom from '@/components/ChatRoom'
 
 export default {
   name: 'PublicRoom',
+  mixins: [Toastification],
   components: {
     Head,
     ChatList,
@@ -33,6 +35,7 @@ export default {
   data() {
     return {
       isLoading: true,
+      isJoin: false,
       chats: [
         {
           isPill: true,
@@ -103,13 +106,16 @@ export default {
     ...mapState(['publicAllMessages']),
   },
   async created() {
-    console.log('created------------joinPublicRoom')
     await this.fetchAllMessages()
+    console.log('created------------joinPublicRoom')
     this.$socket.emit('joinPublicRoom')
+    this.isJoin = true
   },
   beforeDestroy() {
-    console.log('beforeDestroy------------leavePublicRoom')
-    this.$socket.emit('leavePublicRoom')
+    if (this.isJoin) {
+      console.log('beforeDestroy------------leavePublicRoom')
+      this.$socket.emit('leavePublicRoom')
+    }
   },
   sockets: {
     connect() {

--- a/src/views/UserInfo/UserInfo.vue
+++ b/src/views/UserInfo/UserInfo.vue
@@ -7,7 +7,6 @@
       :count="currentViewUser.data.TweetsCount"
       backArrow
     />
-    <button @click="sendMessage">Test message</button>
     <div class="section-wrapper">
       <UserProfile
         :user="currentViewUser.data"
@@ -75,9 +74,6 @@ export default {
     // this.$store.dispatch('handleInitFollowing')
     this.$store.dispatch('isViewCurrentUser', user_id)
     this.fetchUser(user_id)
-    // FIXME:測試用
-    console.log('created------------joinPublicRoom')
-    this.$socket.emit('joinPublicRoom')
   },
   beforeRouteUpdate(to, from, next) {
     const { user_id } = to.params
@@ -87,18 +83,6 @@ export default {
     this.userId = user_id
     this.$store.dispatch('isViewCurrentUser', user_id)
     next()
-  },
-  beforeDestroy() {
-    // FIXME:測試用
-    console.log('beforeDestroy------------leavePublicRoom')
-    this.$socket.emit('leavePublicRoom')
-  },
-  // FIXME:測試用
-  sockets: {
-    connect() {
-      console.log('publicRoon socket connected', this.$socket.connected)
-      this.$socket.emit('joinPublicRoom')
-    },
   },
   methods: {
     async fetchUser(userId) {
@@ -121,14 +105,6 @@ export default {
         })
         this.$router.back()
       }
-    },
-    // FIXME:測試用
-    sendMessage() {
-      console.log('sendMessage')
-      this.$socket.emit('publicMessage', {
-        userId: this.$store.getters.getCurrentUser.id,
-        content: '大家好~~~',
-      })
     },
   },
 }


### PR DESCRIPTION
1.調整修改vuex 儲存訊息資料
2.為了解決announce被蓋過的問題，調整publicRoom先取完歷史訊息在送出join事件
3.修正publicMessage事件參數
4.已另外請後端協助同步publicMessage的資料格式跟歷史訊息一樣
5.修正toast使用、刪除未使用code
6.新增private相關事件監聽、個人資料頁面私訊按鈕新增點擊處理(待測試)
